### PR TITLE
为 LibrimeKit 添加持续集成

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,59 @@
+name: Build LibrimeKit
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Build Boost
+        run: |
+          make boost-build
+
+      - name: Build Librime
+        run: |
+          make librime-build
+
+      - name: Make Archive
+        run: |
+          tar -acf Frameworks.tgz Frameworks
+
+      - name: Upload Archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: librimekit-frameworks
+          path: Frameworks.tgz
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: upload_release_asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: Frameworks.tgz
+          asset_name: Frameworks.tgz
+          asset_content_type: application/gzip


### PR DESCRIPTION
## 为 LibrimeKit 添加持续集成

这个流程会在以下情况执行
- 推送 main 分支的 commit 到 github
- 推送形如 'v*' 标签到 github

每次执行会耗时大于一小时，一般只需关注推送 'v*' 标签的执行，因为这会自动创建 release，并把编译结果上传到 release 页面。

### 需要注意的事情
创建 release 和上传 asset 到 release 需要给 actions 打开写入权限，可以在仓库的 "Settings" -> "Actions" -> "General" -> "Workflow permissions" 里打开

### 我的测试
https://github.com/amorphobia/LibrimeKit/actions

我保留了两条最终的测试，一条是推送了 main 分支的 commit, 另一条是推送了一个标签 "v0.1.0"，推送标签的编译结束后，自动创建了一个 release 并上传了 asset:
https://github.com/amorphobia/LibrimeKit/releases/tag/v0.1.0
