### PR TITLE
Add arm64 simulator support to librime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,5 +44,5 @@ librime-build: librime-check
 	${mkfile_dir}/librimeBuild.sh
 
 librime-clean:
-	rm -rf ${mkfile_dir}/librime.patch.apply
+	rm -rf ${mkfile_dir}/librime*.patch.apply
 	rm -rf librime librime-sbxlm Frameworks/lib*.xcframework lib/*

--- a/librime.patch
+++ b/librime.patch
@@ -1427,7 +1427,7 @@ index ab64c52..4f65c36 100644
  install(TARGETS rime_deployer DESTINATION ${BIN_INSTALL_DIR})
  install(TARGETS rime_dict_manager DESTINATION ${BIN_INSTALL_DIR})
 diff --git a/xcode.mk b/xcode.mk
-index cf07f0c..2118b35 100644
+index cf07f0c..941d489 100644
 --- a/xcode.mk
 +++ b/xcode.mk
 @@ -10,6 +10,74 @@ endif
@@ -1460,7 +1460,7 @@ index cf07f0c..2118b35 100644
 +# RIME_TEST_BUNDLE_IDENTIFIER: 环境变量, 设置 rime_test.xcodeproj 的 bundle identifier 值
 +XCODE_IOS_CROSS_COMPILE_CMAKE_FLAGS = -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/cmake/toolchain/ios.cmake \
 +	-DPLATFORM=$(PLATFORM) \
-+	-DCMAKE_OSX_DEPLOYMENT_TARGET=$(MINVERSION) \
++	-DDEPLOYMENT_TARGET=$(MINVERSION) \
 +	-DENABLE_BITCODE=NO \
 +	-DDEVELOPMENT_TEAM=$(DEVELOPMENT_TEAM) \
 +	-DRIME_BUNDLE_IDENTIFIER=$(RIME_BUNDLE_IDENTIFIER) \

--- a/librimeBuild.sh
+++ b/librimeBuild.sh
@@ -100,11 +100,17 @@ function prepare_library() {
   make xcode/ios/dist
   cp -f ${LIBRIME_ROOT}/dist/lib/librime.a ${RIME_LIB}/${LIBRIME_VARIANT}_simulator_x86_64.a
 
+  # librime build: iOS simulator 64 bit (arm64)
+  export PLATFORM=SIMULATORARM64
+  rm -rf ${LIBRIME_ROOT}/build ${LIBRIME_ROOT}/dist
+  make xcode/ios/dist
+  cp -f ${LIBRIME_ROOT}/dist/lib/librime.a ${RIME_LIB}/${LIBRIME_VARIANT}_simulator_arm64.a
+
   # librime build: arm64
   export PLATFORM=OS64
   rm -rf ${LIBRIME_ROOT}/build ${LIBRIME_ROOT}/dist
   make xcode/ios/dist
-  cp -f ${LIBRIME_ROOT}/dist/lib/librime.a ${RIME_LIB}/${LIBRIME_VARIANT}_arm64.a
+  cp -f ${LIBRIME_ROOT}/dist/lib/librime.a ${RIME_LIB}/${LIBRIME_VARIANT}.a
 
   # transform *.a to xcframework
   rm -rf ${RIME_ROOT}/Frameworks/${LIBRIME_VARIANT}.xcframework
@@ -112,9 +118,11 @@ function prepare_library() {
   # 屏蔽 headers ，双键盘引用不同的 librime frameworke, 在 XCoode 编译期间报错：重复的文件 
   # -library ${RIME_LIB}/${LIBRIME_VARIANT}_simulator_x86_64.a -headers ${LIBRIME_INCLUDE} \
   # -library ${RIME_LIB}/${LIBRIME_VARIANT}_arm64.a -headers ${LIBRIME_INCLUDE} \
+  lipo ${RIME_LIB}/${LIBRIME_VARIANT}_simulator_x86_64.a ${RIME_LIB}/${LIBRIME_VARIANT}_simulator_arm64.a -create -output ${RIME_LIB}/${LIBRIME_VARIANT}_simulator.a
+
   xcodebuild -create-xcframework \
-  -library ${RIME_LIB}/${LIBRIME_VARIANT}_simulator_x86_64.a \
-  -library ${RIME_LIB}/${LIBRIME_VARIANT}_arm64.a \
+  -library ${RIME_LIB}/${LIBRIME_VARIANT}_simulator.a \
+  -library ${RIME_LIB}/${LIBRIME_VARIANT}.a \
   -output ${RIME_ROOT}/Frameworks/${LIBRIME_VARIANT}.xcframework
 
   # clean


### PR DESCRIPTION
给 librime.xcframework 添加 arm64 模拟器支持：

<img width="761" alt="image" src="https://github.com/imfuxiao/LibrimeKit/assets/31927845/3253ac04-f880-4698-8d89-451d079e5b4a">

方法是先编译 3 次，然后用 `lipo` 把 simulator 的两种架构的文件合并成一个 FAT lib，再让 `xcodebuild` 生成。

不过，我按这种方法编译出来的库文件，添加到仓的主程序里编译会报错 `undefined symbols`，不知道是不是因为 Hamster 仓库主分支代码还没更新，麻烦您查看一下。